### PR TITLE
Fix for sending two emails during user self registration

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -44,4 +44,12 @@ public class AccountConstants {
     public static final String EMAIL_TEMPLATE_TYPE_ACC_ENABLED = "accountenable";
 
     public static final String ACCOUNT_LOCK_BYPASS_ROLE = "Internal/system";
+
+    public static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
+    public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
+    public static final String PENDING_EMAIL_VERIFICATION = "PENDING_EV";
+    public static final String LOCKED = "LOCKED";
+    public static final String UNLOCKED = "UNLOCKED";
+    public static final String DISABLED = "DISABLED";
+
 }


### PR DESCRIPTION
Fix for https://github.com/wso2/product-is/issues/5880
Fix for https://github.com/wso2/product-is/issues/5884
### Proposed changes in this pull request

Introduced a new state claim(http://wso2.org/claims/accountState) to store the users' state.

![Untitled Diagram (1)](https://user-images.githubusercontent.com/17597293/60880057-75e4cd80-a260-11e9-9a4a-6b74b6680f8f.jpg)

If the user is in accountState = "pending" state, that means the user's email is not verified yet. If he is in pending state, the accountLocked email will not be sent.

Locked - If accountLocked is true and accountDisabled is false
Pending_Ask_Password - Ask password email is sent and it is not verifies
Pending_Email_Verification - Email verification is sent and it is not verified yet
Pending_Self_Registration - Self registration mail is sent and it is not verified yet
Disabled - If accountDisabled is true
Unlocked - If an accountDisabled claim is false and the accountLocked claim is false


### When should this PR be merged

[Please describe any preconditions that need to be addressed before we
can merge this pull request.]


### Follow up actions

[List any possible follow-up actions here; for instance, testing data
migrations, software that we need to install on staging and production
environments.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description.
- [ ] **Is the PR labeled correctly?**

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled.

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests.
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/).

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components.
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?**
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes should be documented.
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented.
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki.
