### PR TITLE
Maintain the backward compatibility in changing email templates

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
+            <artifactId>org.wso2.carbon.email.mgt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
@@ -122,7 +126,11 @@
                             org.wso2.carbon.identity.governance;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.common;
-                            version="${identity.governance.imp.pkg.version.range}"
+                            version="${identity.governance.imp.pkg.version.range}",
+                            org.wso2.carbon.email.mgt;
+                            version="${identity.event.handler.notification.version.range}",
+                            org.wso2.carbon.email.mgt.exceptions;
+                            version="${identity.event.handler.notification.version.range}",
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -484,37 +484,54 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("User %s is unlocked", userName));
                 }
-
+                String emailTemplateTypeAccUnlocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED;
                 if (notificationInternallyManage) {
                     if (isAdminInitiated) {
-                        triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                identityProperties, AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_ADMIN_TRIGGERED);
+                        if (AccountUtil
+                                .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_ADMIN_TRIGGERED,
+                                        tenantDomain)) {
+                            emailTemplateTypeAccUnlocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_ADMIN_TRIGGERED;
+                        }
                     } else {
-                        triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                identityProperties, AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_TIME_BASED);
+                        if (AccountUtil.isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_TIME_BASED,
+                                tenantDomain)) {
+                            emailTemplateTypeAccUnlocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_TIME_BASED;
+                        }
                     }
-                    newAccountState = buildAccountState(AccountConstants.ACC_UNLOCKED,
-                            tenantDomain, userStoreManager, userName);
+                    triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                            identityProperties, emailTemplateTypeAccUnlocked);
+                    newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED, tenantDomain,
+                            userStoreManager, userName);
                 }
             } else if (lockedStates.LOCKED_MODIFIED.toString().equals(lockedState.get())) {
 
                 if (log.isDebugEnabled()) {
                     log.debug(String.format("User %s is locked", userName));
                 }
+                String emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED;
                 if (notificationInternallyManage) {
                     if (StringUtils.isNotEmpty(existingAccountStateClaimValue)) {
                         // Send locked email only if the accountState claim value is PENDIG_SR or PENDING_EV.
                         if (isAdminInitiated) {
-                            triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                    identityProperties,
-                                    AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED);
+                            if (AccountUtil
+                                    .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED,
+                                            tenantDomain)) {
+                                emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED;
+                            }
                         } else {
-                            triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                    identityProperties, AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT);
+                            if (AccountUtil
+                                    .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT,
+                                            tenantDomain)) {
+                                emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT;
+                            }
                         }
+                        triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                                identityProperties, emailTemplateTypeAccLocked);
+
                         if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue)
-                                && !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue)) {
-                            newAccountState = buildAccountState(AccountConstants.ACC_LOCKED,
+                                && !AccountConstants.PENDING_EMAIL_VERIFICATION
+                                .equals(existingAccountStateClaimValue)) {
+                            newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,
                                     tenantDomain, userStoreManager, userName);
                         }
                     }
@@ -656,11 +673,11 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             if (isAccountDisabled(userStoreManager, userName)) {
                 // If accountDisabled claim is true, then set accountState=DISABLED
                 newAccountstate = AccountConstants.DISABLED;
-            } else if (state.equals(AccountConstants.ACC_UNLOCKED)) {
+            } else if (state.equals(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED)) {
                 // If accountDisabled claim is false and accountLocked claim is false, then set
                 // accountState=UNLOCKED
                 newAccountstate = AccountConstants.UNLOCKED;
-            } else if (state.equals(AccountConstants.ACC_LOCKED)) {
+            } else if (state.equals(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED)) {
                 // If accountDisabled claim is false and accountLocked claim is true, then set
                 // accountState=LOCKED
                 newAccountstate = AccountConstants.LOCKED;

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -37,8 +37,8 @@ public class AccountConstants {
     public static final String LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "account.lock.handler.login.fail.timeout.ratio";
     public static final String NOTIFICATION_INTERNALLY_MANAGE = "account.lock.handler.notification.manageInternally";
 
-    public static final String ACC_LOCKED = "accountlock";
-    public static final String ACC_UNLOCKED = "accountunlock";
+    public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED = "accountlock";
+    public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED = "accountunlock";
 
     public static final String EMAIL_TEMPLATE_TYPE_ACC_DISABLED = "accountdisable";
     public static final String EMAIL_TEMPLATE_TYPE_ACC_ENABLED = "accountenable";

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceComponent.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceComponent.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.identity.handler.event.account.lock.service.AccountLockSe
 import org.wso2.carbon.stratos.common.listeners.TenantMgtListener;
 import org.wso2.carbon.user.core.UserStoreManager;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.email.mgt.EmailTemplateManager;
 
 @Component(
         name = "handler.event.account.lock",
@@ -133,5 +134,26 @@ public class AccountServiceComponent {
     protected void unsetRealmService(RealmService realmService) {
 
         AccountServiceDataHolder.getInstance().setRealmService(null);
+    }
+
+    @Reference(name = "emailTemplateManager.service",
+               service = org.wso2.carbon.email.mgt.EmailTemplateManager.class,
+               cardinality = ReferenceCardinality.MANDATORY,
+               policy = ReferencePolicy.DYNAMIC,
+               unbind = "unsetEmailTemplateManager")
+    protected void setEmailTemplateManager(EmailTemplateManager emailTemplateManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Email Template Manager is registered in Account service.");
+        }
+        AccountServiceDataHolder.getInstance().setEmailTemplateManager(emailTemplateManager);
+    }
+
+    protected void unsetEmailTemplateManager(EmailTemplateManager emailTemplateManager) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Email Template Manager is unregistered in Account service.");
+        }
+        AccountServiceDataHolder.getInstance().setEmailTemplateManager(null);
     }
 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceDataHolder.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceDataHolder.java
@@ -20,6 +20,7 @@ import org.osgi.framework.BundleContext;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.email.mgt.EmailTemplateManager;
 
 public class AccountServiceDataHolder {
 
@@ -29,6 +30,7 @@ public class AccountServiceDataHolder {
     private IdentityGovernanceService identityGovernanceService;
     private IdentityEventService identityEventService;
     private RealmService realmService;
+    private EmailTemplateManager emailTemplateManager;
 
     private AccountServiceDataHolder(){
 
@@ -69,5 +71,15 @@ public class AccountServiceDataHolder {
 
     public void setRealmService(RealmService realmService) {
         this.realmService = realmService;
+    }
+
+    public void setEmailTemplateManager(EmailTemplateManager emailTemplateManager) {
+
+        this.emailTemplateManager = emailTemplateManager;
+    }
+
+    public EmailTemplateManager getEmailTemplateManager() {
+
+        return emailTemplateManager;
     }
 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/util/AccountUtil.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/util/AccountUtil.java
@@ -36,6 +36,7 @@ import org.wso2.carbon.user.api.UserStoreException;
 import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.service.RealmService;
+import org.wso2.carbon.email.mgt.exceptions.I18nEmailMgtException;
 
 public class AccountUtil {
 
@@ -123,5 +124,25 @@ public class AccountUtil {
             throw new AccountLockException("Error while checking accountState claim  from ClaimManager");
         }
         return isExist;
+    }
+
+    /**
+     * This is used to check the existence of a email template.
+     *
+     * @param templateType Template type display name.
+     * @param tenantDomain Tenant domain.
+     * @return Returns true if email template exists.
+     * @throws AccountLockException Account Lock Exception.
+     */
+    public static boolean isTemplateExists(String templateType, String tenantDomain) throws AccountLockException {
+
+        try {
+            return AccountServiceDataHolder.getInstance().getEmailTemplateManager()
+                    .isEmailTemplateTypeExists(templateType, tenantDomain);
+        } catch (I18nEmailMgtException e) {
+            throw new AccountLockException(
+                    "Error occurred while checking email template type: " + templateType + " existence in the "
+                            + "tenantDomain: " + tenantDomain, e);
+        }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,13 @@
                 <version>${carbon.identity.framework.version}</version>
             </dependency>
 
+            <!--Identity Event Handler Email Dependencies-->
+            <dependency>
+                <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
+                <artifactId>org.wso2.carbon.email.mgt</artifactId>
+                <version>${identity.event.handler.notification.version}</version>
+            </dependency>
+
             <!--Carbon Identity Extension Dependencies-->
             <dependency>
                 <groupId>org.wso2.carbon.identity.governance</groupId>
@@ -277,6 +284,10 @@
         <!--Carbon Identity Governance Version-->
         <identity.governance.version>1.3.11</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
+
+        <!--Identity Event Handler Notification Version-->
+        <identity.event.handler.notification.version>1.2.10</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version.range>[1.2.10, 2.0.0)</identity.event.handler.notification.version.range>
 
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
This pr fixes:  for https://github.com/wso2/product-is/issues/6926
As the fix for https://github.com/wso2/product-is/issues/6778 Following changes were done

Added email templates : accountUnlockAdmin, accountLockAdmin, accountUnlockTimeBased,accountLockFailedAttempt

Removed: accountUnlock, accountLock

wso2-extensions/identity-event-handler-notification#107

Documentation: https://github.com/wso2/docs-is/pull/862/files

to maintain the backward compatibility by this fix it will first look for newly added templates if they do not exist then will check for the removed templates. and will use them for notification triggering