### PR TITLE
Clear thread local value

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -539,6 +539,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             }
         } finally {
             lockedState.remove();
+            IdentityUtil.threadLocalProperties.get().remove(AccountConstants.ADMIN_INITIATED);
         }
         if (StringUtils.isNotEmpty(newAccountState)) {
             setUserClaim(AccountConstants.ACCOUNT_STATE_CLAIM_URI, newAccountState,


### PR DESCRIPTION
Fix comments: https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/57

Map returns null if the key does not exists. 

Public issue : https://github.com/wso2/product-is/issues/7346