### PR TITLE
[FIX] Sending account lock notifications for self registration

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -510,30 +510,27 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 }
                 String emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED;
                 if (notificationInternallyManage) {
-                    if (StringUtils.isNotEmpty(existingAccountStateClaimValue)) {
-                        if (isAdminInitiated) {
-                            if (AccountUtil
-                                    .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED,
-                                            tenantDomain)) {
-                                emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED;
-                            }
-                        } else {
-                            if (AccountUtil
-                                    .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT,
-                                            tenantDomain)) {
-                                emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT;
-                            }
+                    if (isAdminInitiated) {
+                        if (AccountUtil.isTemplateExists(
+                                AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED, tenantDomain)) {
+                            emailTemplateTypeAccLocked =
+                                    AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED;
                         }
+                    } else {
+                        if (AccountUtil.isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT,
+                                        tenantDomain)) {
+                            emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT;
+                        }
+                    }
 
-                        // Send locked email only if the accountState claim value neither PENDING_SR or PENDING_EV.
-                        if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue)
-                                && !AccountConstants.PENDING_EMAIL_VERIFICATION
-                                .equals(existingAccountStateClaimValue)) {
-                            newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,
-                                    tenantDomain, userStoreManager, userName);
-                            triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                    identityProperties, emailTemplateTypeAccLocked);
-                        }
+                    // Send locked email only if the accountState claim value neither PENDING_SR or PENDING_EV.
+                    if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue)
+                            && !AccountConstants.PENDING_EMAIL_VERIFICATION
+                            .equals(existingAccountStateClaimValue)) {
+                        newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,
+                                tenantDomain, userStoreManager, userName);
+                        triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                                identityProperties, emailTemplateTypeAccLocked);
                     }
                 }
             }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -511,7 +511,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 String emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED;
                 if (notificationInternallyManage) {
                     if (StringUtils.isNotEmpty(existingAccountStateClaimValue)) {
-                        // Send locked email only if the accountState claim value is PENDIG_SR or PENDING_EV.
                         if (isAdminInitiated) {
                             if (AccountUtil
                                     .isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED,
@@ -525,14 +524,15 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                                 emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT;
                             }
                         }
-                        triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                identityProperties, emailTemplateTypeAccLocked);
 
+                        // Send locked email only if the accountState claim value neither PENDING_SR or PENDING_EV.
                         if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue)
                                 && !AccountConstants.PENDING_EMAIL_VERIFICATION
                                 .equals(existingAccountStateClaimValue)) {
                             newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,
                                     tenantDomain, userStoreManager, userName);
+                            triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                                    identityProperties, emailTemplateTypeAccLocked);
                         }
                     }
                 }


### PR DESCRIPTION
1. Resolves https://github.com/wso2/product-is/issues/5880
2. Resolves https://github.com/wso2/product-is/issues/8242

### Approach
- To resolve 1: Do not trigger notifications if the account state is either `PENDING_SELF_REGISTRATION` or `PENDING_EMAIL_VERIFICATION`
- To resolve 2: Removing validating account state for not being empty before sending notifications