### PR TITLE
[FIX] Tenant wise email sender config is not working for account locking scenario

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
@@ -177,8 +178,14 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             handlePreSetUserClaimValues(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
                     identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
         } else if (IdentityEventConstants.Event.POST_SET_USER_CLAIMS.equals(event.getEventName())) {
-            handlePostSetUserClaimValues(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
+            PrivilegedCarbonContext.startTenantFlow();
+            try {
+                PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);
+                handlePostSetUserClaimValues(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                        identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
+            } finally {
+                PrivilegedCarbonContext.endTenantFlow();
+            }
         }
     }
 


### PR DESCRIPTION
Resolves: https://github.com/wso2/product-is/issues/8481

Front porting: https://github.com/wso2-support/identity-event-handler-account-lock/pull/30