### PR TITLE
Add support to enable account lock/unlock notifications during admin forced password reset

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -138,12 +138,10 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         String adminPasswordResetAccountLockNotificationProperty = IdentityUtil.getProperty(
                 AccountConstants.ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_LOCK_NOTIFICATION_ENABLE_PROPERTY);
         boolean adminForcePasswordResetLockNotificationEnabled =
-                !(adminPasswordResetAccountLockNotificationProperty == null) ||
                         Boolean.parseBoolean(adminPasswordResetAccountLockNotificationProperty);
         String adminPasswordResetAccountUnlockNotificationProperty = IdentityUtil.getProperty(
                 AccountConstants.ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_UNLOCK_NOTIFICATION_ENABLE_PROPERTY);
         boolean adminForcePasswordResetUnlockNotificationEnabled =
-                !(adminPasswordResetAccountUnlockNotificationProperty == null) ||
                         Boolean.parseBoolean(adminPasswordResetAccountUnlockNotificationProperty);
         try {
             identityProperties = AccountServiceDataHolder.getInstance()

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -36,6 +36,10 @@ public class AccountConstants {
     public static final String FAILED_LOGIN_ATTEMPTS_PROPERTY = "account.lock.handler.On.Failure.Max.Attempts";
     public static final String LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "account.lock.handler.login.fail.timeout.ratio";
     public static final String NOTIFICATION_INTERNALLY_MANAGE = "account.lock.handler.notification.manageInternally";
+    public static final String ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_LOCK_NOTIFICATION_ENABLE_PROPERTY =
+            "Recovery.AdminPasswordReset.AccountLockNotification";
+    public static final String ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_UNLOCK_NOTIFICATION_ENABLE_PROPERTY =
+            "Recovery.AdminPasswordReset.AccountUnlockNotification";
 
     public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED = "accountlock";
     public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED = "accountunlock";

--- a/pom.xml
+++ b/pom.xml
@@ -294,12 +294,12 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.180</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Governance Version-->
-        <identity.governance.version>1.3.11</identity.governance.version>
+        <identity.governance.version>1.4.70</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Notification Version-->


### PR DESCRIPTION
### Proposed changes in this pull request
> Public fix for https://github.com/wso2/product-is/issues/9708

### Depends on PRs
> https://github.com/wso2/carbon-identity-framework/pull/3197
> https://github.com/wso2-extensions/identity-governance/pull/445

Before merging
- [x] Merge https://github.com/wso2/carbon-identity-framework/pull/3197
- [x] Merge https://github.com/wso2-extensions/identity-governance/pull/445
- [x] Bump governance version
- [x] PR_BUILDER