### PR TITLE
Fix Handle accountState feature with regard to disabled accounts.

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountDisableHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountDisableHandler.java
@@ -234,6 +234,9 @@ public class AccountDisableHandler extends AbstractEventHandler implements Ident
                     IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                     IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.USER_ACCOUNT_STATE,
                             IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE);
+                    IdentityUtil.threadLocalProperties.get()
+                            .put(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName,
+                                    IdentityCoreConstants.USER_ACCOUNT_DISABLED_ERROR_CODE);
                 }
             } else {
                 if (existingAccountDisabledValue) {

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -373,9 +373,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.USER_ACCOUNT_STATE,
                         UserCoreConstants.ErrorCode.USER_IS_LOCKED);
-
+                IdentityUtil.threadLocalProperties.get()
+                        .put(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName,
+                                UserCoreConstants.ErrorCode.USER_IS_LOCKED);
                 if (log.isDebugEnabled()) {
-                    log.debug(String.format("User %s is locked since he/she exceeded the maximum allowed failed attempts", userName));
+                    log.debug(
+                            String.format("User %s is locked since he/she exceeded the maximum allowed failed attempts",
+                                    userName));
                 }
                 IdentityUtil.threadLocalProperties.get().put(AccountConstants.ADMIN_INITIATED, false);
 
@@ -446,6 +450,9 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     lockedState.set(lockedStates.LOCKED_MODIFIED.toString());
                     IdentityUtil.threadLocalProperties.get().put(IdentityCoreConstants.USER_ACCOUNT_STATE,
                             UserCoreConstants.ErrorCode.USER_IS_LOCKED);
+                    IdentityUtil.threadLocalProperties.get()
+                            .put(IdentityCoreConstants.USER_ACCOUNT_STATE_WITH_USERNAME + userName,
+                                    UserCoreConstants.ErrorCode.USER_IS_LOCKED);
                 }
             } else {
                 if (existingAccountLockedValue) {

--- a/pom.xml
+++ b/pom.xml
@@ -294,7 +294,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.14.67</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.18.177</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
This fix introduces a new user state including username as key in the IdentityUtil.threadLocalProperties which keeps track of the account state until the access token is revoked.


### When should this PR be merged

- [x] merge PR https://github.com/wso2/carbon-identity-framework/pull/3238
- [ ] Bump framework version in IS

### Related PRs
https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1497