### PR TITLE
Stop sending account lock email during lite registration

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -523,13 +523,15 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     }
                     boolean isPendingSelfRegistration =
                             AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue);
+                    boolean isPendingLiteRegistration =
+                            AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue);
                     if (IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
                             .equals(existingAccountStateClaimValue)) {
                         if (adminForcedPasswordResetUnlockNotificationEnabled) {
                             triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain, identityProperties,
                                     emailTemplateTypeAccUnlocked);
                         }
-                    } else if (!isPendingSelfRegistration) {
+                    } else if (!isPendingSelfRegistration && !isPendingLiteRegistration) {
                         triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain, identityProperties,
                                 emailTemplateTypeAccUnlocked);
                     }
@@ -566,9 +568,11 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                             triggerNotification(event, userName, userStoreManager, userStoreDomainName,
                                     tenantDomain, identityProperties, emailTemplateTypeAccLocked);
                         }
-                        // Send locked email only if the accountState claim value is neither PENDIG_SR nor PENDING_EV.
+                        // Send locked email only if the accountState claim value doesn't have PENDIG_SR, PENDING_EV
+                        // or PENDING_LR.
                     } else if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue) &&
-                            !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue)) {
+                            !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue) &&
+                            !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue)) {
                         triggerNotification(event, userName, userStoreManager, userStoreDomainName,
                                 tenantDomain, identityProperties, emailTemplateTypeAccLocked);
                         newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -52,6 +52,7 @@ public class AccountConstants {
     public static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
     public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
     public static final String PENDING_EMAIL_VERIFICATION = "PENDING_EV";
+    public static final String PENDING_LITE_REGISTRATION = "PENDING_LR";
     public static final String LOCKED = "LOCKED";
     public static final String UNLOCKED = "UNLOCKED";
     public static final String DISABLED = "DISABLED";


### PR DESCRIPTION
### Proposed changes in this pull request

Resolves https://github.com/wso2/product-is/issues/10886
Governance level we already handled this \[1]

\[1] https://github.com/wso2-extensions/identity-governance/blob/master/components/org.wso2.carbon.identity.recovery/src/main/java/org/wso2/carbon/identity/recovery/handler/LiteUserRegistrationHandler.java#L156

Need to update the document. Created a doc issue \[2]

\[2] https://github.com/wso2/product-is/issues/10914