### PR TITLE
Fix locked reason claim value

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -50,6 +50,7 @@ public class AccountConstants {
     public static final String ACCOUNT_LOCK_BYPASS_ROLE = "Internal/system";
 
     public static final String ACCOUNT_STATE_CLAIM_URI = "http://wso2.org/claims/identity/accountState";
+    public static final String ACCOUNT_LOCKED_REASON_CLAIM_URI = "http://wso2.org/claims/identity/lockedReason";
     public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
     public static final String PENDING_EMAIL_VERIFICATION = "PENDING_EV";
     public static final String PENDING_LITE_REGISTRATION = "PENDING_LR";

--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Governance Version-->
-        <identity.governance.version>1.4.70</identity.governance.version>
+        <identity.governance.version>1.4.79</identity.governance.version>
         <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Notification Version-->


### PR DESCRIPTION
### Description
This fix will add the values to the LockedReason claim values to track the locked reason. With this PR, following locked reasons are added.

    ADMIN_INITIATED,
    MAX_ATTEMPTS_EXCEEDED
    PENDING_SELF_REGISTRATION
    PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
    PENDING_EMAIL_VERIFICATION
    PENDING_ASK_PASSWORD
    IDLE_ACCOUNT

Related PR: wso2-support/identity-governance#298
Resolves: wso2/product-is#10867

### When should this PR be merged
After merging https://github.com/wso2-extensions/identity-governance/pull/472