### PR TITLE
Fix forced user password reset state issue

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -596,11 +596,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                                 tenantDomain, identityProperties, emailTemplateTypeAccLocked);
                     }
                 }
-                /* Set new account state only if the accountState claim value is neither PENDING_SR, PENDING_EV nor
-                PENDING_LR. */
+                /* Set new account state only if the accountState claim value is neither PENDING_SR, PENDING_EV,
+                PENDING_LR nor PENDING_FUPR. */
                 if (!AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue) &&
                         !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue) &&
-                        !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue)) {
+                        !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue) &&
+                        !AccountConstants.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
+                                .equals(existingAccountStateClaimValue)) {
                     newAccountState = buildAccountState(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED,
                             tenantDomain, userStoreManager, userName);
                 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -54,6 +54,7 @@ public class AccountConstants {
     public static final String PENDING_SELF_REGISTRATION = "PENDING_SR";
     public static final String PENDING_EMAIL_VERIFICATION = "PENDING_EV";
     public static final String PENDING_LITE_REGISTRATION = "PENDING_LR";
+    public static final String PENDING_ADMIN_FORCED_USER_PASSWORD_RESET = "PENDING_FUPR";
     public static final String LOCKED = "LOCKED";
     public static final String UNLOCKED = "UNLOCKED";
     public static final String DISABLED = "DISABLED";


### PR DESCRIPTION
This PR fixes the following issues which are mentioned in the related ticket.
- [x] Account State claim becomes LOCKED, it should be PENDING_FUPR.
- [x] Once the user resets the password, the account unlocked email is sent to the user, when the account unlock notification is disabled for the admin forced password reset.

Fixes: wso2/product-is#11593