### PR TITLE
Implementing account lock for failed login attempts

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -16,6 +16,9 @@
 
 package org.wso2.carbon.identity.handler.event.account.lock.constants;
 
+/**
+ * Constants class.
+ */
 public class AccountConstants {
 
     public static final String ACCOUNT_LOCKED_CLAIM = "http://wso2.org/claims/identity/accountLocked";

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.18.206</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.91</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
### Proposed changes in this pull request
In the current MF authenticators, account lock for failed attempt feature has been implemented inside the authenticator. This PR provides support to use account lock handler to lock user account. 

### Before merging this PR
-  [ ] Merge https://github.com/wso2/carbon-identity-framework/pull/3568
-  [ ] Bump framework version in IS.