### PR TITLE
Improve account lock handling for authenticators

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -220,6 +220,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             } finally {
                 PrivilegedCarbonContext.endTenantFlow();
             }
+        } else if (IdentityEventConstants.Event.POST_NON_BASIC_AUTHENTICATION.equals(event.getEventName())) {
+            /*
+            This will be invoked when an authenticator fires event POST_AUTHENTICATOR_LOGIN_ATTEMPT. This is similar to
+            the POST_AUTHENTICATION.
+             */
+            handleAuthenticatorLoginAttempt(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
         }
     }
 
@@ -236,6 +243,21 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         }
 
         return true;
+    }
+
+    protected boolean handleAuthenticatorLoginAttempt(Event event, String userName, UserStoreManager userStoreManager,
+                                                        String userStoreDomainName, String tenantDomain,
+                                                        Property[] identityProperties, int maximumFailedAttempts,
+                                                        String accountLockTime, double unlockTimeRatio)
+            throws AccountLockException {
+
+        /*
+        This is similar to the POST_AUTHENTICATION. If the authentication attempt at the authenticator is successful,
+        we need to reset any failed login attempts. If the authentication failed, we need to increment failed login
+        attempts and lock the user if the account lock criteria is satisfied.
+         */
+        return handlePostAuthentication(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
     }
 
     protected boolean handlePostAuthentication(Event event, String userName, UserStoreManager userStoreManager,

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -222,10 +222,10 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             }
         } else if (IdentityEventConstants.Event.POST_NON_BASIC_AUTHENTICATION.equals(event.getEventName())) {
             /*
-            This will be invoked when an authenticator fires event POST_AUTHENTICATOR_LOGIN_ATTEMPT. This is similar to
+            This will be invoked when an authenticator fires event POST_NON_BASIC_AUTHENTICATION. This is similar to
             the POST_AUTHENTICATION.
              */
-            handleAuthenticatorLoginAttempt(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+            handleNonBasicAuthentication(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
                     identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
         }
     }
@@ -245,10 +245,10 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         return true;
     }
 
-    protected boolean handleAuthenticatorLoginAttempt(Event event, String userName, UserStoreManager userStoreManager,
-                                                        String userStoreDomainName, String tenantDomain,
-                                                        Property[] identityProperties, int maximumFailedAttempts,
-                                                        String accountLockTime, double unlockTimeRatio)
+    protected boolean handleNonBasicAuthentication(Event event, String userName, UserStoreManager userStoreManager,
+                                                   String userStoreDomainName, String tenantDomain,
+                                                   Property[] identityProperties, int maximumFailedAttempts,
+                                                   String accountLockTime, double unlockTimeRatio)
             throws AccountLockException {
 
         /*

--- a/pom.xml
+++ b/pom.xml
@@ -223,7 +223,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.91</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.20.95</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 


### PR DESCRIPTION
Improvements related to https://github.com/wso2/carbon-identity-framework/pull/3581. 

### Proposed changes in this pull request
This PR handles account locking for authenticators as a different event.