### PR TITLE
Add support for sending notification emails on every lockout cycle, and add lock duration info to the email

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -396,18 +396,9 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 currentFailedLoginLockouts += 1;
 
                 if (currentFailedLoginLockouts > 1) {
-                    boolean notificationOnLockIncrement = false;
-                    try {
-                        notificationOnLockIncrement = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
-                                .NOTIFY_ON_LOCK_DURATION_INCREMENT, tenantDomain));
-                    } catch (IdentityEventException e) {
-                        log.warn("Error while reading notification on lock increment property in account lock handler. "
-                                + e.getMessage());
-                        if (log.isDebugEnabled()) {
-                            log.debug("Error while reading notification on lock increment property in account lock " +
-                                    "handler", e);
-                        }
-                    }
+                    boolean notificationOnLockIncrement = getNotificationOnLockIncrementConfig(tenantDomain);
+                    // If the 'NOTIFY_ON_LOCK_DURATION_INCREMENT' config is enabled, trigger the account lock email
+                    // notification with the new lock duration information.
                     if (notificationOnLockIncrement) {
                         Property identityProperty = new Property();
                         identityProperty.setName(AccountConstants.ACCOUNT_UNLOCK_TIME);
@@ -1046,5 +1037,28 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             userLockedDuration = (long) Math.ceil((accountUnlockTime - System.currentTimeMillis())/60000.0);
         }
         return Long.toString(userLockedDuration);
+    }
+
+    /**
+     * Get the account lock connector configuration to decide whether to trigger notifications on every lockout cycle.
+     *
+     * @param tenantDomain  Tenant Domain.
+     * @return  Whether the config is enabled not not.
+     */
+    private boolean getNotificationOnLockIncrementConfig(String tenantDomain) {
+
+        boolean notificationOnLockIncrement = false;
+        try {
+            notificationOnLockIncrement = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
+                    .NOTIFY_ON_LOCK_DURATION_INCREMENT, tenantDomain));
+        } catch (IdentityEventException e) {
+            log.warn("Error while reading notification on lock increment property in account lock handler. "
+                    + e.getMessage());
+            if (log.isDebugEnabled()) {
+                log.debug("Error while reading notification on lock increment property in account lock " +
+                        "handler", e);
+            }
+        }
+        return notificationOnLockIncrement;
     }
 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -113,7 +113,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         nameMapping.put(AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY, "Initial account lock duration");
         nameMapping.put(AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY, "Account lock duration increment factor");
         nameMapping.put(AccountConstants.NOTIFICATION_INTERNALLY_MANAGE, "Manage notification sending internally");
-        nameMapping.put(AccountConstants.NOTIFY_ON_LOCK_DURATION_INCREMENT, "Notify user on account lock increment");
+        nameMapping.put(AccountConstants.NOTIFY_ON_LOCK_DURATION_INCREMENT, "Notify user when lock time is increased");
         return nameMapping;
     }
 
@@ -129,8 +129,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 "increased by this factor. Ex: Initial duration: 5m; Increment factor: 2; Next lock duration: 5 x 2 = 10m.");
         descriptionMapping.put(AccountConstants.NOTIFICATION_INTERNALLY_MANAGE, "Disable if the client application " +
                 "handles notification sending.");
-        descriptionMapping.put(AccountConstants.NOTIFY_ON_LOCK_DURATION_INCREMENT, "Notify user via email when the " +
-                "account lock duration increases on consecutive lock cycles.");
+        descriptionMapping.put(AccountConstants.NOTIFY_ON_LOCK_DURATION_INCREMENT, "Notify user when the account " +
+                "lock duration is increased due to continuous failed login attempts.");
         return descriptionMapping;
     }
 

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -120,15 +120,15 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
         Map<String, String> descriptionMapping = new HashMap<>();
-        descriptionMapping.put(AccountConstants.ACCOUNT_LOCKED_PROPERTY, "Lock user accounts on failed login attempts.");
+        descriptionMapping.put(AccountConstants.ACCOUNT_LOCKED_PROPERTY, "Lock user accounts on failed login attempts");
         descriptionMapping.put(AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY, "Number of failed login attempts " +
                 "allowed until account lock.");
         descriptionMapping.put(AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY, "Initial account lock time period in " +
                 "minutes. Account will be automatically unlocked after this time period.");
         descriptionMapping.put(AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY, "Account lock duration will be " +
-                "increased by this factor. Ex: Initial duration: 5m; Increment factor: 2; Next lock duration: 5 x 2 = 10m.");
+                "increased by this factor. Ex: Initial duration: 5m; Increment factor: 2; Next lock duration: 5 x 2 = 10m");
         descriptionMapping.put(AccountConstants.NOTIFICATION_INTERNALLY_MANAGE, "Disable if the client application " +
-                "handles notification sending.");
+                "handles notification sending");
         descriptionMapping.put(AccountConstants.NOTIFY_ON_LOCK_DURATION_INCREMENT, "Notify user when the account " +
                 "lock duration is increased due to continuous failed login attempts.");
         return descriptionMapping;

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -17,6 +17,7 @@
 package org.wso2.carbon.identity.handler.event.account.lock;
 
 import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
@@ -354,6 +355,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             currentFailedAttempts += 1;
             newClaims.put(failedAttemptsClaim, Integer.toString(currentFailedAttempts));
             newClaims.put(AccountConstants.FAILED_LOGIN_ATTEMPTS_BEFORE_SUCCESS_CLAIM, "0");
+            long accountLockDuration = 0;
 
             if (AccountUtil.isAccountLockByPassForUser(userStoreManager, userName)) {
                 IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(INVALID_CREDENTIAL,
@@ -386,16 +388,35 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                          */
                         unlockTimePropertyValue = (long) (unlockTimePropertyValue * 1000 * 60 * Math.pow
                                 (unlockTimeRatio, currentFailedLoginLockouts));
+                        accountLockDuration = unlockTimePropertyValue/60000;
                         unlockTime = System.currentTimeMillis() + unlockTimePropertyValue;
-                        IdentityUtil.threadLocalProperties.get().put(AccountConstants.USER_LOCKED_DURATION,
-                                Long.toString(unlockTimePropertyValue/60000));
                         newClaims.put(AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM, Long.toString(unlockTime));
                     }
                 }
                 currentFailedLoginLockouts += 1;
+
                 if (currentFailedLoginLockouts > 1) {
-                    IdentityUtil.threadLocalProperties.get().put(AccountConstants.LOCK_EXTENDED, true);
+                    boolean notificationOnLockIncrement = false;
+                    try {
+                        notificationOnLockIncrement = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
+                                .NOTIFY_ON_LOCK_DURATION_INCREMENT, tenantDomain));
+                    } catch (IdentityEventException e) {
+                        log.warn("Error while reading notification on lock increment property in account lock handler. "
+                                + e.getMessage());
+                        if (log.isDebugEnabled()) {
+                            log.debug("Error while reading notification on lock increment property in account lock " +
+                                    "handler", e);
+                        }
+                    }
+                    if (notificationOnLockIncrement) {
+                        Property identityProperty = new Property();
+                        identityProperty.setName(AccountConstants.ACCOUNT_UNLOCK_TIME);
+                        identityProperty.setValue(Long.toString(accountLockDuration));
+                        triggerNotificationOnAccountLockIncrement(userName, userStoreManager, userStoreDomainName,
+                                tenantDomain, event, new Property[]{ identityProperty });
+                    }
                 }
+
                 newClaims.put(FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, Integer.toString(currentFailedLoginLockouts));
                 newClaims.put(failedAttemptsClaim, "0");
 
@@ -588,6 +609,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     }
                 }
                 if (notificationInternallyManage) {
+                    Property[] properties = null;
                     if (isAdminInitiated) {
                         if (AccountUtil.isTemplateExists(
                                 AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED, tenantDomain)) {
@@ -598,6 +620,11 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                         if (AccountUtil.isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT,
                                         tenantDomain)) {
                             emailTemplateTypeAccLocked = AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT;
+                            Property identityProperty = new Property();
+                            identityProperty.setName(AccountConstants.ACCOUNT_UNLOCK_TIME);
+                            identityProperty.setValue(getAccountLockDuration(
+                                    getClaimValue(userName, userStoreManager, AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM)));
+                            properties = new Property[]{ identityProperty };
                         }
                     }
 
@@ -615,7 +642,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                             !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue) &&
                             !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue)) {
                         triggerNotification(event, userName, userStoreManager, userStoreDomainName,
-                                tenantDomain, identityProperties, emailTemplateTypeAccLocked);
+                                tenantDomain, properties, emailTemplateTypeAccLocked);
                     }
                 }
                 /* Set new account state only if the accountState claim value is neither PENDING_SR, PENDING_EV,
@@ -633,38 +660,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 auditAccountLock(AuditConstants.ACCOUNT_LOCKED, userName, userStoreDomainName, isAdminInitiated,
                         null, AuditConstants.AUDIT_SUCCESS, true);
             } else if (lockedStates.LOCKED_UNMODIFIED.toString().equals(lockedState.get())) {
-                boolean notificationOnLockIncrement = false;
-                try {
-                    notificationOnLockIncrement = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
-                            .NOTIFY_ON_LOCK_DURATION_INCREMENT, tenantDomain));
-                } catch (IdentityEventException e) {
-                    log.warn("Error while reading notification on lock increment property in account lock handler");
-                    if (log.isDebugEnabled()) {
-                        log.debug("Error while reading notification on lock increment property in account lock " +
-                                "handler", e);
-                    }
-                }
-
-                if (notificationOnLockIncrement &&
-                        IdentityUtil.threadLocalProperties.get().get(AccountConstants.LOCK_EXTENDED) != null) {
-                    boolean isAccountLockExtended = (boolean) IdentityUtil.threadLocalProperties.get()
-                            .get(AccountConstants.LOCK_EXTENDED);
-                    if (isAccountLockExtended && !isAdminInitiated && notificationInternallyManage &&
-                            AccountUtil.isTemplateExists(AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT,
-                                    tenantDomain)) {
-
-                        // Send locked email only if the accountState claim value doesn't have PENDING_AFUPR,
-                        // PENDING_SR, PENDING_EV or PENDING_LR.
-                        if (!IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET.equals(
-                                existingAccountStateClaimValue) &&
-                                !AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue) &&
-                                !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue) &&
-                                !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue)) {
-                            triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                                    identityProperties, AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT);
-                        }
-                    }
-                }
                 auditAccountLock(AuditConstants.ACCOUNT_LOCKED, userName, userStoreDomainName, isAdminInitiated,
                         null, AuditConstants.AUDIT_SUCCESS, false);
             } else if (lockedStates.UNLOCKED_UNMODIFIED.toString().equals(lockedState.get())) {
@@ -674,8 +669,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         } finally {
             lockedState.remove();
             IdentityUtil.threadLocalProperties.get().remove(AccountConstants.ADMIN_INITIATED);
-            IdentityUtil.threadLocalProperties.get().remove(AccountConstants.USER_LOCKED_DURATION);
-            IdentityUtil.threadLocalProperties.get().remove(AccountConstants.LOCK_EXTENDED);
         }
         if (StringUtils.isNotEmpty(newAccountState)) {
             userClaims.put(AccountConstants.ACCOUNT_STATE_CLAIM_URI, newAccountState);
@@ -719,13 +712,14 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         properties.put(IdentityEventConstants.EventProperty.USER_STORE_DOMAIN, userStoreDomainName);
         properties.put(IdentityEventConstants.EventProperty.TENANT_DOMAIN, tenantDomain);
         properties.put("TEMPLATE_TYPE", notificationEvent);
-        if (AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT.equals(notificationEvent)) {
-            String userLockedDuration = (String) IdentityUtil.threadLocalProperties.get().
-                    get(AccountConstants.USER_LOCKED_DURATION);
-            if (StringUtils.isNotEmpty(userLockedDuration)) {
-                properties.put(AccountConstants.LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER, userLockedDuration);
-            } else {
-                properties.put(AccountConstants.LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER, "0");
+
+        if (AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT.equals(notificationEvent) &&
+                ArrayUtils.isNotEmpty(identityProperties)) {
+            for (Property property : identityProperties) {
+                if (AccountConstants.ACCOUNT_UNLOCK_TIME.equals(property.getName())) {
+                    properties.put(AccountConstants.LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER, property.getValue());
+                    break;
+                }
             }
         }
         Event identityMgtEvent = new Event(eventName, properties);
@@ -987,5 +981,70 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             return FAILED_LOGIN_ATTEMPTS_CLAIM;
         }
         return String.valueOf(eventProperties.get(PROPERTY_FAILED_LOGIN_ATTEMPTS_CLAIM));
+    }
+
+    /**
+     * Send email notification to the user when the account lock duration is incremented due to further failed login
+     * attempts.
+     */
+    private void triggerNotificationOnAccountLockIncrement(String userName, UserStoreManager userStoreManager,
+                                                           String userStoreDomainName, String tenantDomain, Event event,
+                                                           Property[] identityProperties) throws AccountLockException {
+
+        boolean notificationInternallyManage = true;
+        try {
+            notificationInternallyManage = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
+                    .NOTIFICATION_INTERNALLY_MANAGE, tenantDomain));
+        } catch (IdentityEventException e) {
+            log.warn("Error while reading Notification internally manage property in account lock handler." +
+                    e.getMessage());
+            if (log.isDebugEnabled()) {
+                log.debug("Error while reading Notification internally manage property in account lock handler", e);
+            }
+        }
+
+        if (notificationInternallyManage && AccountUtil.isTemplateExists
+                (AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT, tenantDomain)) {
+            String existingAccountStateClaimValue = getAccountState(userStoreManager, tenantDomain, userName);
+
+            // Send locked email only if the accountState claim value doesn't have PENDING_AFUPR, PENDING_SR,
+            // PENDING_EV or PENDING_LR.
+            if (!IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET.equals(
+                    existingAccountStateClaimValue) &&
+                    !AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue) &&
+                    !AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue) &&
+                    !AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue)) {
+                triggerNotification(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
+                        identityProperties, AccountConstants.EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT);
+            }
+        }
+    }
+
+    /**
+     * Calculate account lock duration by considering the unlock time claim and the current time.
+     *
+     * @param accountUnlockTimeClaim UnlockTime claim value.
+     * @return  Lock duration in minutes.
+     */
+    private String getAccountLockDuration(String accountUnlockTimeClaim) {
+
+        long accountUnlockTime = 0;
+        if (StringUtils.isNotEmpty(accountUnlockTimeClaim)) {
+            try {
+                accountUnlockTime = Long.parseLong(accountUnlockTimeClaim);
+            } catch (NumberFormatException e) {
+                String errorMsg = "Error occurred while parsing the account locked duration, " +
+                        "detail : " + e.getMessage();
+                log.warn(errorMsg);
+                if (log.isDebugEnabled()) {
+                    log.debug(errorMsg, e);
+                }
+            }
+        }
+        long userLockedDuration = 0;
+        if (accountUnlockTime > 0) {
+            userLockedDuration = (long) Math.ceil((accountUnlockTime - System.currentTimeMillis())/60000.0);
+        }
+        return Long.toString(userLockedDuration);
     }
 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -39,6 +39,8 @@ public class AccountConstants {
     public static final String FAILED_LOGIN_ATTEMPTS_PROPERTY = "account.lock.handler.On.Failure.Max.Attempts";
     public static final String LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY = "account.lock.handler.login.fail.timeout.ratio";
     public static final String NOTIFICATION_INTERNALLY_MANAGE = "account.lock.handler.notification.manageInternally";
+    public static final String NOTIFY_ON_LOCK_DURATION_INCREMENT =
+            "account.lock.handler.notification.notifyOnLockIncrement";
     public static final String ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_LOCK_NOTIFICATION_ENABLE_PROPERTY =
             "Recovery.AdminPasswordReset.AccountLockNotification";
     public static final String ADMIN_FORCE_PASSWORD_RESET_ACCOUNT_UNLOCK_NOTIFICATION_ENABLE_PROPERTY =
@@ -61,8 +63,10 @@ public class AccountConstants {
     public static final String LOCKED = "LOCKED";
     public static final String UNLOCKED = "UNLOCKED";
     public static final String DISABLED = "DISABLED";
+    public static final String LOCK_EXTENDED = "LOCK_EXTENDED";
 
     public static final String ADMIN_INITIATED = "AdminInitiated";
+    public static final String USER_LOCKED_DURATION = "UserLockedDuration";
 
     public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED = "accountlockadmin";
     public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_ADMIN_TRIGGERED = "accountunlockadmin";
@@ -70,4 +74,5 @@ public class AccountConstants {
     public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED_FAILED_ATTEMPT = "accountlockfailedattempt";
     public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_TIME_BASED = "accountunlocktimebased";
 
+    public static final String LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER = "lock-duration";
 }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -63,10 +63,9 @@ public class AccountConstants {
     public static final String LOCKED = "LOCKED";
     public static final String UNLOCKED = "UNLOCKED";
     public static final String DISABLED = "DISABLED";
-    public static final String LOCK_EXTENDED = "LOCK_EXTENDED";
 
     public static final String ADMIN_INITIATED = "AdminInitiated";
-    public static final String USER_LOCKED_DURATION = "UserLockedDuration";
+    public static final String ACCOUNT_UNLOCK_TIME = "AccountUnlockTime";
 
     public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED = "accountlockadmin";
     public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_ADMIN_TRIGGERED = "accountunlockadmin";


### PR DESCRIPTION
### Proposed changes in this pull request

- Add support for sending notification emails on every lockout cycle based on a new config introduced to the account lock governance connector.
- Add information about the account locked duration to the current notification sent when account is locked due to max failed login attempts.

### When should this PR be merged
After https://github.com/wso2/carbon-identity-framework/pull/3604 and https://github.com/wso2/carbon-identity-framework/pull/3604
