### PR TITLE
Revert "Remove config to enable account lock handler globally, and add a new config to enable account lock on max failed attempts"

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -31,8 +31,7 @@ public class AccountConstants {
     public static final String FAILED_LOGIN_ATTEMPTS_BEFORE_SUCCESS_CLAIM =
             "http://wso2.org/claims/identity/failedLoginAttemptsBeforeSuccess";
 
-    public static final String ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY =
-            "account.lock.handler.lock.on.max.failed.attempts.enable";
+    public static final String ACCOUNT_LOCKED_PROPERTY = "account.lock.handler.enable";
     public static final String ACCOUNT_DISABLED_PROPERTY = "account.disable.handler.enable";
     public static final String ACCOUNT_DISABLED_NOTIFICATION_INTERNALLY_MANAGE = "account.disable.handler.notification.manageInternally";
 


### PR DESCRIPTION
Reverts wso2-extensions/identity-event-handler-account-lock#96