### PR TITLE
Remove config to enable account lock handler globally, and add a new config to enable account lock on max failed attempts

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -109,7 +109,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
     public Map<String, String> getPropertyNameMapping() {
         Map<String, String> nameMapping = new HashMap<>();
-        nameMapping.put(AccountConstants.ACCOUNT_LOCKED_PROPERTY, "Lock user accounts");
+        nameMapping.put(AccountConstants.ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY,
+                "Lock user accounts on maximum failed attempts");
         nameMapping.put(AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY, "Maximum failed login attempts");
         nameMapping.put(AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY, "Initial account lock duration");
         nameMapping.put(AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY, "Account lock duration increment factor");
@@ -121,7 +122,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
     @Override
     public Map<String, String> getPropertyDescriptionMapping() {
         Map<String, String> descriptionMapping = new HashMap<>();
-        descriptionMapping.put(AccountConstants.ACCOUNT_LOCKED_PROPERTY, "Lock user accounts on failed login attempts");
+        descriptionMapping.put(AccountConstants.ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY,
+                "Lock user accounts on failed login attempts");
         descriptionMapping.put(AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY, "Number of failed login attempts " +
                 "allowed until account lock.");
         descriptionMapping.put(AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY, "Initial account lock time period in " +
@@ -150,7 +152,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         String tenantDomain = (String) eventProperties.get(IdentityEventConstants.EventProperty.TENANT_DOMAIN);
 
         Property[] identityProperties;
-        boolean accountLockedEnabled = false;
+        boolean accountLockOnFailedAttemptsEnabled = false;
         String accountLockTime = "0";
         int maximumFailedAttempts = 0;
         double unlockTimeRatio = 1;
@@ -169,8 +171,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             throw new IdentityEventException("Error while retrieving Account Locking Handler properties.", e);
         }
         for (Property identityProperty : identityProperties) {
-            if (AccountConstants.ACCOUNT_LOCKED_PROPERTY.equals(identityProperty.getName())) {
-                accountLockedEnabled = Boolean.parseBoolean(identityProperty.getValue());
+            if (AccountConstants.ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY.equals(identityProperty.getName())) {
+                accountLockOnFailedAttemptsEnabled = Boolean.parseBoolean(identityProperty.getValue());
             } else if (AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY.equals(identityProperty.getName())) {
                 String value = identityProperty.getValue();
                 if (NumberUtils.isNumber(value)) {
@@ -186,13 +188,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     }
                 }
             }
-        }
-
-        if (!accountLockedEnabled) {
-            if (log.isDebugEnabled()) {
-                log.debug("Account lock handler is disabled in tenant: " + tenantDomain);
-            }
-            return;
         }
 
         String usernameWithDomain = UserCoreUtil.addDomainToName(userName, userStoreDomainName);
@@ -211,7 +206,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
         } else if (IdentityEventConstants.Event.POST_AUTHENTICATION.equals(event.getEventName())) {
             handlePostAuthentication(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
+                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio,
+                    accountLockOnFailedAttemptsEnabled);
         } else if (IdentityEventConstants.Event.PRE_SET_USER_CLAIMS.equals(event.getEventName())) {
             handlePreSetUserClaimValues(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
                     identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
@@ -233,7 +229,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             the POST_AUTHENTICATION.
              */
             handleNonBasicAuthentication(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
+                    identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio,
+                    accountLockOnFailedAttemptsEnabled);
         }
     }
 
@@ -255,7 +252,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
     protected boolean handleNonBasicAuthentication(Event event, String userName, UserStoreManager userStoreManager,
                                                    String userStoreDomainName, String tenantDomain,
                                                    Property[] identityProperties, int maximumFailedAttempts,
-                                                   String accountLockTime, double unlockTimeRatio)
+                                                   String accountLockTime, double unlockTimeRatio,
+                                                   boolean accountLockOnFailedAttemptsEnabled)
             throws AccountLockException {
 
         /*
@@ -264,13 +262,15 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         attempts and lock the user if the account lock criteria is satisfied.
          */
         return handlePostAuthentication(event, userName, userStoreManager, userStoreDomainName, tenantDomain,
-                identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio);
+                identityProperties, maximumFailedAttempts, accountLockTime, unlockTimeRatio,
+                accountLockOnFailedAttemptsEnabled);
     }
 
     protected boolean handlePostAuthentication(Event event, String userName, UserStoreManager userStoreManager,
                                                String userStoreDomainName, String tenantDomain,
                                                Property[] identityProperties, int maximumFailedAttempts,
-                                               String accountLockTime, double unlockTimeRatio)
+                                               String accountLockTime, double unlockTimeRatio,
+                                               boolean accountLockOnFailedAttemptsEnabled)
             throws AccountLockException {
 
         long unlockTime = getUnlockTime(userName, userStoreManager);
@@ -306,6 +306,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
                 throw new AccountLockException(USER_IS_LOCKED, message);
             }
+        }
+
+        if (!accountLockOnFailedAttemptsEnabled) {
+            if (log.isDebugEnabled()) {
+                log.debug("Account lock on failed login attempts is disabled in tenant: " + tenantDomain);
+            }
+            return true;
         }
 
         Map<String, Object> eventProperties = event.getEventProperties();
@@ -676,7 +683,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
     public String[] getPropertyNames() {
         List<String> properties = new ArrayList<>();
-        properties.add(AccountConstants.ACCOUNT_LOCKED_PROPERTY);
+        properties.add(AccountConstants.ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY);
         properties.add(AccountConstants.FAILED_LOGIN_ATTEMPTS_PROPERTY);
         properties.add(AccountConstants.ACCOUNT_UNLOCK_TIME_PROPERTY);
         properties.add(AccountConstants.LOGIN_FAIL_TIMEOUT_RATIO_PROPERTY);

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -31,7 +31,8 @@ public class AccountConstants {
     public static final String FAILED_LOGIN_ATTEMPTS_BEFORE_SUCCESS_CLAIM =
             "http://wso2.org/claims/identity/failedLoginAttemptsBeforeSuccess";
 
-    public static final String ACCOUNT_LOCKED_PROPERTY = "account.lock.handler.enable";
+    public static final String ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY =
+            "account.lock.handler.lock.on.max.failed.attempts.enable";
     public static final String ACCOUNT_DISABLED_PROPERTY = "account.disable.handler.enable";
     public static final String ACCOUNT_DISABLED_NOTIFICATION_INTERNALLY_MANAGE = "account.disable.handler.notification.manageInternally";
 

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/service/AccountLockServiceImpl.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/service/AccountLockServiceImpl.java
@@ -47,10 +47,6 @@ public class AccountLockServiceImpl implements AccountLockService {
 
         UserStoreManager userStoreManager = getUserStoreManager(tenantDomain);
 
-        if (!isAccountLockingEnabled(tenantDomain)) {
-            return false;
-        }
-
         boolean accountLocked = getAccountLockClaimValue(domainAwareUsername, userStoreManager);
         if (accountLocked) {
             if (isAccountLockByPassForUser(userStoreManager, domainAwareUsername)) {
@@ -133,35 +129,6 @@ public class AccountLockServiceImpl implements AccountLockService {
         } catch (UserStoreException e) {
             throw new AccountLockServiceException("Could not retrieve user store for tenant domain: " + tenantDomain,
                     e);
-        }
-    }
-
-    private boolean isAccountLockingEnabled(String tenantDomain) throws AccountLockServiceException {
-
-        try {
-            Property[] identityProperties = AccountServiceDataHolder.getInstance().getIdentityGovernanceService()
-                    .getConfiguration(new String[]{AccountConstants.ACCOUNT_LOCKED_PROPERTY}, tenantDomain);
-
-            boolean accountLockingEnabled = false;
-            if (identityProperties != null) {
-                for (Property property : identityProperties) {
-                    if (AccountConstants.ACCOUNT_LOCKED_PROPERTY.equals(property.getName())) {
-                        accountLockingEnabled = Boolean.parseBoolean(property.getValue());
-                    }
-                }
-            } else {
-                if (log.isDebugEnabled()) {
-                    log.debug("Identity event properties is null.");
-                }
-            }
-
-            if (log.isDebugEnabled()) {
-                log.debug(String.format("Account lock feature(%s) is enabled: %s for tenant: %s",
-                        AccountConstants.ACCOUNT_LOCKED_PROPERTY, accountLockingEnabled, tenantDomain));
-            }
-            return accountLockingEnabled;
-        } catch (IdentityGovernanceException e) {
-            throw new AccountLockServiceException("Error while checking account locking capability status.", e);
         }
     }
 


### PR DESCRIPTION
Reapply the changes reverted in https://github.com/wso2/product-is/pull/12321 along with a modification to fix user not getting locked when user's account lock claim is updated.
