### PR TITLE
Add functionality to reset failed login attempts before success

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -344,6 +344,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             // Return if user authentication is successful on the first try.
             if (!Boolean.parseBoolean(accountLockClaim) && currentFailedAttempts == 0 &&
                     currentFailedLoginLockouts == 0 && unlockTime == 0) {
+                newClaims.put(AccountConstants.FAILED_LOGIN_ATTEMPTS_BEFORE_SUCCESS_CLAIM, "0");
+                setUserClaims(userName, tenantDomain, userStoreManager, newClaims);
                 return true;
             }
 


### PR DESCRIPTION
Related Issues: https://github.com/wso2/product-is/issues/4992
### Proposed changes in this pull request

After a successful authentication in first attempt, need to reset `failedLoginAttemptsBeforeSuccess` claim value to 0. Reason for this is, after a few failed logins, user will successfully logged into the application. But when that happen, `failedLoginAttemptsBeforeSuccess` will not be reset to 0. So when the user tries to log next time (first attempt as his last attempt also a success), the  `failedLoginAttemptsBeforeSuccess` is not 0. So when using login based adaptive authentication, the second step will be triggered. (Which is not an expected scenario).
