### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -223,17 +223,17 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.20.95</carbon.identity.framework.version>
-        <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.framework.imp.pkg.version.range>[6.0.0, 7.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 
         <!--Carbon Identity Governance Version-->
-        <identity.governance.version>1.8.4</identity.governance.version>
-        <identity.governance.imp.pkg.version.range>[1.3.9, 2.0.0)</identity.governance.imp.pkg.version.range>
+        <identity.governance.version>2.0.0</identity.governance.version>
+        <identity.governance.imp.pkg.version.range>[2.0.0, 3.0.0)</identity.governance.imp.pkg.version.range>
 
         <!--Identity Event Handler Notification Version-->
-        <identity.event.handler.notification.version>1.2.10</identity.event.handler.notification.version>
-        <identity.event.handler.notification.version.range>[1.2.10, 2.0.0)</identity.event.handler.notification.version.range>
+        <identity.event.handler.notification.version>2.0.0</identity.event.handler.notification.version>
+        <identity.event.handler.notification.version.range>[2.0.0, 3.0.0)</identity.event.handler.notification.version.range>
 
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16