### PR TITLE
Introducing new post authentication handler to reset failed login lockout count claim

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
@@ -57,6 +57,10 @@
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
             <artifactId>org.wso2.carbon.identity.central.log.mgt</artifactId>
         </dependency>
         <dependency>
@@ -138,6 +142,8 @@
                             org.wso2.carbon.identity.event.handler;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
                             org.wso2.carbon.identity.event.services;
+                            version="${carbon.identity.framework.imp.pkg.version.range}",
+                            org.wso2.carbon.identity.application.authentication.framework.*;
                             version="${carbon.identity.framework.imp.pkg.version.range}",
 
                             org.wso2.carbon.stratos.common.*; version="${carbon.commons.imp.pkg.version}",

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -401,7 +401,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 newClaims.put(failedAttemptsClaim, "0");
                 newClaims.put(ACCOUNT_UNLOCK_TIME_CLAIM, "0");
                 newClaims.put(ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
-                newClaims.put(FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
                 IdentityUtil.threadLocalProperties.get().put(AccountConstants.ADMIN_INITIATED, false);
             }
             setUserClaims(userName, tenantDomain, userStoreManager, newClaims);

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -25,6 +25,7 @@ import org.apache.commons.logging.LogFactory;
 import org.json.JSONObject;
 import org.slf4j.MDC;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
 import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.core.bean.context.MessageContext;
 import org.wso2.carbon.identity.core.handler.InitConfig;
@@ -401,6 +402,15 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                 newClaims.put(failedAttemptsClaim, "0");
                 newClaims.put(ACCOUNT_UNLOCK_TIME_CLAIM, "0");
                 newClaims.put(ACCOUNT_LOCKED_CLAIM, Boolean.FALSE.toString());
+                boolean isAuthenticationFrameworkFlow = false;
+                if (IdentityUtil.threadLocalProperties.get().get(
+                        FrameworkConstants.AUTHENTICATION_FRAMEWORK_FLOW) != null) {
+                    isAuthenticationFrameworkFlow = (boolean) IdentityUtil.threadLocalProperties.get().get(
+                            FrameworkConstants.AUTHENTICATION_FRAMEWORK_FLOW);
+                }
+                if (!isAuthenticationFrameworkFlow) {
+                    newClaims.put(FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+                }
                 IdentityUtil.threadLocalProperties.get().put(AccountConstants.ADMIN_INITIATED, false);
             }
             setUserClaims(userName, tenantDomain, userStoreManager, newClaims);

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
@@ -18,15 +18,6 @@
 
 package org.wso2.carbon.identity.handler.event.account.lock.handlers;
 
-import static org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED;
-import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_CLAIM;
-import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM;
-
-import java.util.HashMap;
-import java.util.Map;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.apache.commons.lang.math.NumberUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -49,6 +40,16 @@ import org.wso2.carbon.user.api.UserStoreManager;
 import org.wso2.carbon.user.core.UserRealm;
 import org.wso2.carbon.user.core.constants.UserCoreErrorConstants;
 import org.wso2.carbon.user.core.service.RealmService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_CLAIM;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM;
 
 /**
  * Handles resetting failed login lockout count upon after a successful authentication flow.

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
@@ -99,6 +99,9 @@ public class PostAuthnFailedLockoutClaimHandler extends AbstractPostAuthnHandler
 
         AuthenticatedUser authenticatedUser = context.getSequenceConfig().getAuthenticatedUser();
         try {
+            if (authenticatedUser == null) {
+                return SUCCESS_COMPLETED;
+            }
             /* Check whether account locking enabled and user is a local user.
             Account locking is not done for federated flows. */
             if (authenticatedUser.isFederatedUser() || isAccountLockingDisabled(authenticatedUser.getTenantDomain())) {

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
@@ -1,0 +1,167 @@
+
+/*
+ * Copyright (c) 2022, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.handler.event.account.lock.handlers;
+
+import static org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus.SUCCESS_COMPLETED;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.ACCOUNT_LOCKED_CLAIM;
+import static org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.commons.lang.math.NumberUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.authentication.framework.context.AuthenticationContext;
+import org.wso2.carbon.identity.application.authentication.framework.exception.FrameworkException;
+import org.wso2.carbon.identity.application.authentication.framework.exception.PostAuthenticationFailedException;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.AbstractPostAuthnHandler;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthnHandlerFlowStatus;
+import org.wso2.carbon.identity.application.authentication.framework.model.AuthenticatedUser;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkErrorConstants;
+import org.wso2.carbon.identity.application.authentication.framework.util.FrameworkUtils;
+import org.wso2.carbon.identity.application.common.model.Property;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
+import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
+import org.wso2.carbon.identity.handler.event.account.lock.internal.AccountServiceDataHolder;
+import org.wso2.carbon.user.api.UserStoreException;
+import org.wso2.carbon.user.api.UserStoreManager;
+import org.wso2.carbon.user.core.UserRealm;
+import org.wso2.carbon.user.core.service.RealmService;
+
+/**
+ * Handles resetting failed login lockout count upon after a successful authentication flow.
+ */
+public class PostAuthnFailedLockoutClaimHandler extends AbstractPostAuthnHandler {
+
+    private static final Log log = LogFactory.getLog(PostAuthnFailedLockoutClaimHandler.class);
+    private static volatile PostAuthnFailedLockoutClaimHandler instance = new PostAuthnFailedLockoutClaimHandler();
+    private static final String handlerName = "PostAuthnFailedLockoutClaimHandler";
+    private static final String LOCAL_AUTHENTICATOR = "LOCAL";
+    private static final String ERROR_WHILE_GETTING_USER_STORE_MANAGER_ERROR_CODE = "80022";
+    public static final String ACCOUNT_LOCK_HANDLER_ENABLE_PROPERTY = "account.lock.handler.enable";
+
+    /**
+     * To get an instance of {@link PostAuthnFailedLockoutClaimHandler}.
+     *
+     * @return an instance of PostJITProvisioningHandler.
+     */
+    public static PostAuthnFailedLockoutClaimHandler getInstance() {
+
+        return instance;
+    }
+
+    /**
+     * To avoid creation of multiple instances of this handler.
+     */
+    protected PostAuthnFailedLockoutClaimHandler() {
+
+    }
+
+    @Override
+    public int getPriority() {
+
+        int priority = super.getPriority();
+        if (priority == -1) {
+            priority = 21;
+        }
+        return priority;
+    }
+
+    @Override
+    public String getName() {
+
+        return handlerName;
+    }
+
+    @Override
+    public PostAuthnHandlerFlowStatus handle(HttpServletRequest request, HttpServletResponse response,
+                                             AuthenticationContext context) throws PostAuthenticationFailedException {
+
+        AuthenticatedUser authenticatedUser = context.getSequenceConfig().getAuthenticatedUser();
+        try {
+            /* Check whether account locking enabled and user is a local user.
+            Account locking is not done for federated flows. */
+            if (authenticatedUser.isFederatedUser() || isAccountLockingDisabled(authenticatedUser.getTenantDomain())) {
+                return SUCCESS_COMPLETED;
+            }
+            String usernameWithDomain = IdentityUtil.addDomainToName(
+                    authenticatedUser.getUserName(), authenticatedUser.getUserStoreDomain());
+            UserRealm realm = getUserRealm(authenticatedUser.getTenantDomain());
+            UserStoreManager userStoreManager = realm.getUserStoreManager();
+            if (userStoreManager.isExistingUser(usernameWithDomain)) {
+                Map<String, String> claimValues = getUserClaims(userStoreManager, usernameWithDomain);
+                String accountLockClaim = claimValues.get(ACCOUNT_LOCKED_CLAIM);
+                if (accountLockClaim != null && !Boolean.parseBoolean(accountLockClaim)) {
+                    String failedLoginLockoutCount =
+                            claimValues.get(FAILED_LOGIN_LOCKOUT_COUNT_CLAIM);
+                    // check if the value is already not zero
+                    if (NumberUtils.isNumber(failedLoginLockoutCount) && Integer.parseInt(failedLoginLockoutCount) > 0) {
+                        Map<String, String> updatedClaims = new HashMap<>();
+                        updatedClaims.put(FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, "0");
+                        userStoreManager.setUserClaimValues(usernameWithDomain, updatedClaims, null);
+                    }
+                }
+            }
+
+        } catch (UserStoreException e) {
+            throw new PostAuthenticationFailedException(ERROR_WHILE_GETTING_USER_STORE_MANAGER_ERROR_CODE,
+                    "Error occurred while retrieving user store manager.");
+        } catch (FrameworkException e) {
+            throw new PostAuthenticationFailedException(
+                    FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_CLAIM_MAPPINGS.getCode(),
+                    FrameworkErrorConstants.ErrorMessages.ERROR_WHILE_GETTING_CLAIM_MAPPINGS.getMessage(), e);
+        }
+
+        return SUCCESS_COMPLETED;
+    }
+
+    private UserRealm getUserRealm(String tenantDomain) throws UserStoreException {
+
+        RealmService realmService = AccountServiceDataHolder.getInstance().getRealmService();
+        int tenantId = IdentityTenantUtil.getTenantId(tenantDomain);
+        return (UserRealm) realmService.getTenantUserRealm(tenantId);
+    }
+
+    private Map<String, String> getUserClaims(UserStoreManager userStoreManager, String authenticatedUser)
+            throws FrameworkException {
+
+        try {
+            Map<String, String> claimValues = userStoreManager.getUserClaimValues(
+                    authenticatedUser,
+                    new String[] {FrameworkConstants.ACCOUNT_LOCKED_CLAIM_URI, FAILED_LOGIN_LOCKOUT_COUNT_CLAIM},
+                    null);
+            return claimValues;
+
+        } catch (UserStoreException e) {
+            throw new FrameworkException("Error occurred while retrieving user claims", e);
+        }
+    }
+
+    private boolean isAccountLockingDisabled(String tenantDomain) throws FrameworkException {
+
+        Property accountLockConfigProperty = FrameworkUtils.getResidentIdpConfiguration(
+                AccountConstants.ACCOUNT_LOCK_MAX_FAILED_ATTEMPTS_PROPERTY, tenantDomain);
+
+        return !(accountLockConfigProperty != null && Boolean.parseBoolean(accountLockConfigProperty.getValue()));
+    }
+}

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/handlers/PostAuthnFailedLockoutClaimHandler.java
@@ -70,7 +70,7 @@ public class PostAuthnFailedLockoutClaimHandler extends AbstractPostAuthnHandler
     /**
      * To get an instance of {@link PostAuthnFailedLockoutClaimHandler}.
      *
-     * @return an instance of PostJITProvisioningHandler.
+     * @return an instance of PostAuthnFailedLockoutClaimHandler.
      */
     public static PostAuthnFailedLockoutClaimHandler getInstance() {
 
@@ -126,7 +126,7 @@ public class PostAuthnFailedLockoutClaimHandler extends AbstractPostAuthnHandler
             }
 
         } catch (UserStoreException e) {
-            // If user not found e, then continue
+            // If user not found e, then continue.
             if (!e.getMessage().contains(UserCoreErrorConstants.ErrorMessages.ERROR_CODE_NON_EXISTING_USER.getCode())) {
                 throw new PostAuthenticationFailedException(ERROR_WHILE_GETTING_USER_STORE_MANAGER_ERROR_CODE,
                         "Error occurred while retrieving user store manager.");

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceComponent.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/internal/AccountServiceComponent.java
@@ -25,12 +25,14 @@ import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
 import org.wso2.carbon.email.mgt.EmailTemplateManager;
+import org.wso2.carbon.identity.application.authentication.framework.handler.request.PostAuthenticationHandler;
 import org.wso2.carbon.identity.event.handler.AbstractEventHandler;
 import org.wso2.carbon.identity.event.services.IdentityEventService;
 import org.wso2.carbon.identity.governance.IdentityGovernanceService;
 import org.wso2.carbon.identity.handler.event.account.lock.AccountDisableHandler;
 import org.wso2.carbon.identity.handler.event.account.lock.AccountLockHandler;
 import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
+import org.wso2.carbon.identity.handler.event.account.lock.handlers.PostAuthnFailedLockoutClaimHandler;
 import org.wso2.carbon.identity.handler.event.account.lock.listener.AccountLockTenantMgtListener;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableService;
 import org.wso2.carbon.identity.handler.event.account.lock.service.AccountDisableServiceImpl;
@@ -78,6 +80,10 @@ public class AccountServiceComponent {
             if (log.isDebugEnabled()) {
                 log.debug("AccountLockTenantMgtListener is registered");
             }
+            PostAuthenticationHandler postAuthnFailedLockoutClaimHandler = PostAuthnFailedLockoutClaimHandler
+                    .getInstance();
+            context.getBundleContext()
+                    .registerService(PostAuthenticationHandler.class.getName(), postAuthnFailedLockoutClaimHandler, null);
             try {
                 UserStoreManager userStoreManager = AccountServiceDataHolder.getInstance().getRealmService()
                         .getBootstrapRealm().getUserStoreManager();

--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
         <carbon.user.api.imp.pkg.version.range>[1.0.1, 2.0.0)</carbon.user.api.imp.pkg.version.range>
 
         <!--Carbon Identity Framework Version-->
-        <carbon.identity.framework.version>5.25.36</carbon.identity.framework.version>
+        <carbon.identity.framework.version>5.25.55</carbon.identity.framework.version>
         <carbon.identity.framework.imp.pkg.version.range>[5.14.67, 6.0.0)
         </carbon.identity.framework.imp.pkg.version.range>
 

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,11 @@
             </dependency>
             <dependency>
                 <groupId>org.wso2.carbon.identity.framework</groupId>
+                <artifactId>org.wso2.carbon.identity.application.authentication.framework</artifactId>
+                <version>${carbon.identity.framework.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.framework</groupId>
                 <artifactId>org.wso2.carbon.identity.event</artifactId>
                 <version>${carbon.identity.framework.version}</version>
             </dependency>


### PR DESCRIPTION
### Proposed changes in this pull request

A new post authentication handler is introduced to reset the failedLoginLockoutCount claim for authentications coming through the authentication framework. 
The existing reset logic is left as it is with a condition since same post authentication event gets triggered for password grant flow which does not comes through the authentication framework.