### PR TITLE
Fix return locked reason query param when max attempts exceeded

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -70,6 +70,8 @@ public class AccountConstants {
     public static final String DISABLED = "DISABLED";
 
     public static final String ADMIN_INITIATED = "AdminInitiated";
+    public static final String MAX_ATTEMPTS_EXCEEDED = "MaxAttemptsExceeded";
+
     public static final String ACCOUNT_UNLOCK_TIME = "AccountUnlockTime";
 
     public static final String EMAIL_TEMPLATE_TYPE_ACC_LOCKED_ADMIN_TRIGGERED = "accountlockadmin";


### PR DESCRIPTION
### Proposed changes in this pull request

- Add locked reason to the error code in scenario where account is locked due to exceeding max attempts.

Notes: 
- For the admin initiated scenario, the locked reason has already been added in [1]. 
- In order to preserve existing behaviour, the value for locked reason is defined as a String constant in `AccountLockHandler` class (similar to the approach used in [1]) and used, rather than using the direct string representation of the locked reason claim value.

Resolves: https://github.com/wso2/product-is/issues/15800

[1] https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/101


