### PR TITLE
Add missing authenticator specific account lock count claim retrieval.

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -323,10 +323,10 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
         } catch (UserStoreException e) {
             throw new AccountLockException(String.format("Error occurred while retrieving %s , %s , %s , %s, %s " +
-                            "and %s claim values.", AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
+                            "and %s claim values for user domain.", AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
                     AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, AccountConstants.FAILED_LOGIN_ATTEMPTS_CLAIM,
                     AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
-                    failedAttemptsClaim), e);
+                    failedAttemptsClaim, userStoreDomainName), e);
         }
 
         long unlockTime = getUnlockTime(claimValues.get(AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM));

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -307,19 +307,26 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                                                boolean accountLockOnFailedAttemptsEnabled) throws AccountLockException {
 
         Map<String, String> claimValues = null;
+
+        // Resolve the claim which stores failed attempts depending on the authenticator.
+        Map<String, Object> eventProperties = event.getEventProperties();
+        String authenticator = String.valueOf(eventProperties.get(AUTHENTICATOR_NAME));
+        String failedAttemptsClaim = resolveFailedLoginAttemptsCounterClaim(authenticator, eventProperties);
+
         try {
             claimValues = userStoreManager.getUserClaimValues(userName,
                     new String[]{AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
                             AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM,
                             AccountConstants.FAILED_LOGIN_ATTEMPTS_CLAIM, AccountConstants.ACCOUNT_LOCKED_CLAIM,
-                            AccountConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI}, UserCoreConstants.DEFAULT_PROFILE);
+                            AccountConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI, failedAttemptsClaim},
+                    UserCoreConstants.DEFAULT_PROFILE);
 
         } catch (UserStoreException e) {
-            throw new AccountLockException(String.format("Error occurred while retrieving %s , %s , %s , %s and %s " +
-                            "claim values for user %s in domain %s", AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
+            throw new AccountLockException(String.format("Error occurred while retrieving %s , %s , %s , %s, %s " +
+                            "and %s claim values.", AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
                     AccountConstants.FAILED_LOGIN_LOCKOUT_COUNT_CLAIM, AccountConstants.FAILED_LOGIN_ATTEMPTS_CLAIM,
-                    AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI, userName,
-                    userStoreDomainName), e);
+                    AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_LOCKED_REASON_CLAIM_URI,
+                    failedAttemptsClaim), e);
         }
 
         long unlockTime = getUnlockTime(claimValues.get(AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM));
@@ -388,11 +395,6 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             }
             return true;
         }
-
-        Map<String, Object> eventProperties = event.getEventProperties();
-        String authenticator = String.valueOf(eventProperties.get(AUTHENTICATOR_NAME));
-        // Resolve the claim which stores failed attempts depending on the authenticator.
-        String failedAttemptsClaim = resolveFailedLoginAttemptsCounterClaim(authenticator, eventProperties);
 
         int currentFailedAttempts = 0;
         int currentFailedLoginLockouts = 0;


### PR DESCRIPTION
### Describe
The account lock feature was not working for `custom authenticators`, as the claim retrieval part for `failedLoginAttempts` for a custom authenticator was not included.

Resolves https://github.com/wso2-enterprise/asgardeo-product/issues/17785

Related Issues: https://github.com/wso2/product-is/issues/15850