### PR TITLE
Add check for wso2 system username

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/util/AccountUtil.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/util/AccountUtil.java
@@ -264,7 +264,10 @@ public class AccountUtil {
         String initiator = null;
 
         if (LoggerUtils.isLogMaskingEnable) {
-            if (StringUtils.isNotBlank(tenantDomain) && StringUtils.isNotBlank(loggedInUser)) {
+            // If the loggedInUser is resolved as the system user, getInitiatorId will return null.
+            // No need to perform an unnecessary DB call.
+            if (StringUtils.isNotBlank(tenantDomain) && StringUtils.isNotBlank(loggedInUser) &&
+                    !AuditConstants.REGISTRY_SYSTEM_USERNAME.equals(loggedInUser)) {
                 initiator = IdentityUtil.getInitiatorId(loggedInUser, tenantDomain);
             }
             if (StringUtils.isBlank(initiator)) {


### PR DESCRIPTION
### Proposed changes in this pull request

For system initiated actions, `loggedInUser` is resolved as `wso2.system.user`. In this case, `getInitiatorId` method returns null since this user is not available in the user store. Added a check to avoid an unnecessary DB call to improve performance