### PR TITLE
Fix max failed attempts exceeded error message for password grant

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -380,7 +380,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                     IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(
                             USER_IS_LOCKED + ":" + AccountConstants.MAX_ATTEMPTS_EXCEEDED);
                     IdentityUtil.setIdentityErrorMsg(customErrorMessageContext);
-                    throw new AccountLockException(USER_IS_LOCKED + ":" + AccountConstants.MAX_ATTEMPTS_EXCEEDED, message);
+                    throw new AccountLockException(USER_IS_LOCKED, message);
                 }
 
                 IdentityErrorMsgContext customErrorMessageContext = new IdentityErrorMsgContext(USER_IS_LOCKED);


### PR DESCRIPTION
### Purpose

Change the error description returned for the password grant when maximum failed attempts is reached

Before fix
```
{"error_description":"17003:MaxAttemptsExceeded Error when handling event : POST_AUTHENTICATION","error":"invalid_grant"}
```

After fix
```
{"error_description":"17003 Account is locked for user: amanda in user store: PRIMARY in tenant: carbon.super. Cannot login until the account is unlocked.","error":"invalid_grant"}
```

### Related Issues
- https://github.com/wso2/product-is/issues/20266
- https://github.com/wso2-enterprise/wso2-iam-internal/issues/1480
