### PR TITLE
Remove Identity Recovery Dependency

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
@@ -68,10 +68,6 @@
             <artifactId>org.wso2.carbon.identity.governance</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wso2.carbon.identity.governance</groupId>
-            <artifactId>org.wso2.carbon.identity.recovery</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.wso2.carbon.identity.event.handler.notification</groupId>
             <artifactId>org.wso2.carbon.email.mgt</artifactId>
         </dependency>
@@ -159,8 +155,6 @@
                             org.wso2.carbon.identity.governance;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.identity.governance.common;
-                            version="${identity.governance.imp.pkg.version.range}",
-                            org.wso2.carbon.identity.recovery;
                             version="${identity.governance.imp.pkg.version.range}",
                             org.wso2.carbon.email.mgt;
                             version="${identity.event.handler.notification.version.range}",

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -45,7 +45,6 @@ import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountCons
 import org.wso2.carbon.identity.handler.event.account.lock.exception.AccountLockException;
 import org.wso2.carbon.identity.handler.event.account.lock.internal.AccountServiceDataHolder;
 import org.wso2.carbon.identity.handler.event.account.lock.util.AccountUtil;
-import org.wso2.carbon.identity.recovery.IdentityRecoveryConstants;
 import org.wso2.carbon.user.core.UserCoreConstants;
 import org.wso2.carbon.user.core.UserStoreException;
 import org.wso2.carbon.user.core.UserStoreManager;
@@ -1288,11 +1287,11 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
             emailVerificationProperties =
                     AccountServiceDataHolder.getInstance().getIdentityGovernanceService()
                             .getConfiguration(new String[]{
-                                            IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION},
+                                            AccountConstants.EMAIL_ACCOUNT_LOCK_ON_CREATION},
                                     tenantDomain);
             if (ArrayUtils.isNotEmpty(emailVerificationProperties) &&
                     emailVerificationProperties.length == 1 &&
-                    IdentityRecoveryConstants.ConnectorConfig.EMAIL_ACCOUNT_LOCK_ON_CREATION.equals(
+                    AccountConstants.EMAIL_ACCOUNT_LOCK_ON_CREATION.equals(
                             emailVerificationProperties[0].getName())) {
                 accountLockOnCreationEnabled =
                         Boolean.parseBoolean(emailVerificationProperties[0].getValue());

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -1,17 +1,19 @@
 /*
- * Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2016-2024, WSO2 LLC. (http://www.wso2.com).
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
  * You may obtain a copy of the License at
  *
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations und
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 
 package org.wso2.carbon.identity.handler.event.account.lock.constants;
@@ -81,5 +83,7 @@ public class AccountConstants {
     public static final String EMAIL_TEMPLATE_TYPE_ACC_UNLOCKED_TIME_BASED = "accountunlocktimebased";
 
     public static final String LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER = "lock-duration";
+
+    public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -110,11 +110,6 @@
                 <artifactId>org.wso2.carbon.identity.governance</artifactId>
                 <version>${identity.governance.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.wso2.carbon.identity.governance</groupId>
-                <artifactId>org.wso2.carbon.identity.recovery</artifactId>
-                <version>${identity.governance.version}</version>
-            </dependency>
 
             <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>


### PR DESCRIPTION
### Purpose

- Removing `org.wso2.carbon.identity.recovery` dependency since it introduces a circular dependancy. 

### Related PRs
- https://github.com/wso2-extensions/identity-event-handler-account-lock/pull/134