### PR TITLE
Discontinue System Role Creation for Sub orgs when in Org creation

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>org.wso2.carbon.email.mgt</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+            <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.felix</groupId>
             <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
             <scope>provided</scope>
@@ -160,6 +164,8 @@
                             version="${identity.event.handler.notification.version.range}",
                             org.wso2.carbon.email.mgt.exceptions;
                             version="${identity.event.handler.notification.version.range}",
+                            org.wso2.carbon.identity.organization.management.service.*;
+                            version="${org.wso2.carbon.identity.organization.management.core.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/listener/AccountLockTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/listener/AccountLockTenantMgtListener.java
@@ -21,10 +21,12 @@ package org.wso2.carbon.identity.handler.event.account.lock.listener;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.identity.core.AbstractIdentityTenantMgtListener;
+import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.handler.event.account.lock.constants.AccountConstants;
 import org.wso2.carbon.identity.handler.event.account.lock.internal.AccountServiceDataHolder;
-import org.wso2.carbon.stratos.common.beans.TenantInfoBean;
 import org.wso2.carbon.stratos.common.exception.StratosException;
+import org.wso2.carbon.identity.organization.management.service.util.OrganizationManagementUtil;
+import org.wso2.carbon.identity.organization.management.service.exception.OrganizationManagementException;
 
 /**
  * Tenant activation listener for Account Lock component to do the task when the tenant get create.
@@ -39,10 +41,16 @@ public class AccountLockTenantMgtListener extends AbstractIdentityTenantMgtListe
         if (log.isDebugEnabled()) {
             log.debug("AccountLockTenantMgtListener is fired for Tenant ID : " + tenantId);
         }
-
+        String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
+        boolean isOrganization = false;
         try {
-            AccountServiceDataHolder.getInstance().getRealmService().getTenantUserRealm(tenantId).
-                    getUserStoreManager().addRole(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, null, null, false);
+            isOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
+            if(!isOrganization) {
+                AccountServiceDataHolder.getInstance().getRealmService().getTenantUserRealm(tenantId).
+                        getUserStoreManager().addRole(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, null, null, false);
+            }
+        } catch (OrganizationManagementException e) {
+            log.error(String.format("Error while checking is sub org by tenant domain: %s", tenantDomain), e);
         } catch (org.wso2.carbon.user.api.UserStoreException e) {
             log.error(String.format("Error while adding role: %s on Tenant: %d",
                     AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, tenantId), e);

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/listener/AccountLockTenantMgtListener.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/listener/AccountLockTenantMgtListener.java
@@ -42,10 +42,8 @@ public class AccountLockTenantMgtListener extends AbstractIdentityTenantMgtListe
             log.debug("AccountLockTenantMgtListener is fired for Tenant ID : " + tenantId);
         }
         String tenantDomain = IdentityTenantUtil.getTenantDomain(tenantId);
-        boolean isOrganization = false;
         try {
-            isOrganization = OrganizationManagementUtil.isOrganization(tenantDomain);
-            if(!isOrganization) {
+            if(!OrganizationManagementUtil.isOrganization(tenantDomain)) {
                 AccountServiceDataHolder.getInstance().getRealmService().getTenantUserRealm(tenantId).
                         getUserStoreManager().addRole(AccountConstants.ACCOUNT_LOCK_BYPASS_ROLE, null, null, false);
             }

--- a/pom.xml
+++ b/pom.xml
@@ -251,7 +251,7 @@
         <identity.event.handler.notification.version>1.2.10</identity.event.handler.notification.version>
         <identity.event.handler.notification.version.range>[1.2.10, 2.0.0)</identity.event.handler.notification.version.range>
 
-        <org.wso2.carbon.identity.organization.management.core.version>1.0.90
+        <org.wso2.carbon.identity.organization.management.core.version>1.1.8
         </org.wso2.carbon.identity.organization.management.core.version>
         <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
         </org.wso2.carbon.identity.organization.management.core.version.range>

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
+                <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
+                <version>${org.wso2.carbon.identity.organization.management.core.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.wso2.carbon.identity.event.handler.accountlock</groupId>
                 <artifactId>org.wso2.carbon.identity.handler.event.account.lock</artifactId>
                 <version>${project.version}</version>
@@ -245,6 +251,11 @@
         <identity.event.handler.notification.version>1.2.10</identity.event.handler.notification.version>
         <identity.event.handler.notification.version.range>[1.2.10, 2.0.0)</identity.event.handler.notification.version.range>
 
+        <org.wso2.carbon.identity.organization.management.core.version>1.0.90
+        </org.wso2.carbon.identity.organization.management.core.version>
+        <org.wso2.carbon.identity.organization.management.core.version.range>[1.0.0, 2.0.0)
+        </org.wso2.carbon.identity.organization.management.core.version.range>
+        
         <!--Maven Plugin Version-->
         <carbon.p2.plugin.version>1.5.3</carbon.p2.plugin.version>
         <maven.compiler.plugin.version>2.3.1</maven.compiler.plugin.version>


### PR DESCRIPTION
### Proposed changes in this pull request
- Currently, the system org role is created in sub org creation.
- But this org roles should be shared to sub org when app is sharing with the sub org.
- Hence, from this changes, we are discontinuing the system roles creation on sub org creation. 
