### PR TITLE
Stop Sending Account Unlock Email when LockOnCreation is Enabled and If the Flow is Password Set

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -703,6 +703,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                             AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue);
                     boolean isPendingAskPassword =
                             AccountConstants.PENDING_ASK_PASSWORD.equals(existingAccountStateClaimValue);
+                    boolean isPasswordSetFlow = false;
+                    if (IdentityUtil.threadLocalProperties.get() != null &&
+                            IdentityUtil.threadLocalProperties.get().get(AccountConstants.PASSWORD_SET_FLOW) != null) {
+                        isPasswordSetFlow = (boolean) IdentityUtil.threadLocalProperties.get()
+                                .get(AccountConstants.PASSWORD_SET_FLOW);
+                    }
+
                     if (IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
                             .equals(existingAccountStateClaimValue)) {
                         if (adminForcedPasswordResetUnlockNotificationEnabled) {
@@ -710,7 +717,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                                     emailTemplateTypeAccUnlocked);
                         }
                     } else if (!isPendingSelfRegistration && !isPendingLiteRegistration &&
-                            !(isPendingAskPassword && isAccountLockOnCreationEnabled(tenantDomain))) {
+                            !((isPendingAskPassword || isPasswordSetFlow) &&
+                                    isAccountLockOnCreationEnabled(tenantDomain))) {
                         triggerNotification(userName, userStoreDomainName, tenantDomain, identityProperties,
                                 emailTemplateTypeAccUnlocked);
                     }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -67,6 +67,7 @@ public class AccountConstants {
     public static final String PENDING_LITE_REGISTRATION = "PENDING_LR";
     public static final String PENDING_ADMIN_FORCED_USER_PASSWORD_RESET = "PENDING_FUPR";
     public static final String PENDING_ASK_PASSWORD = "PENDING_AP";
+    public static final String PASSWORD_SET_FLOW = "PasswordSetFlow";
     public static final String LOCKED = "LOCKED";
     public static final String UNLOCKED = "UNLOCKED";
     public static final String DISABLED = "DISABLED";


### PR DESCRIPTION
### Proposed changes in this pull request

- $Subject

### Related PRs
- https://github.com/wso2-extensions/identity-governance/pull/823