### PR TITLE
Check Previous Account State Claim Value before Sending Unlock Email

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -664,7 +664,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
             String existingAccountStateClaimValue = getAccountState(claimValues.get(AccountConstants
                     .ACCOUNT_STATE_CLAIM_URI), tenantDomain);
-            String previousAccountStateClaimValue = "";
+            String previousAccountStateClaimValue = StringUtils.EMPTY;
             if (IdentityUtil.threadLocalProperties.get().get(AccountConstants.PREVIOUS_ACCOUNT_STATE) != null) {
                 previousAccountStateClaimValue =
                         getAccountState(

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -582,10 +582,12 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
         try {
             claimValues = userStoreManager.getUserClaimValues(userName,
-                    new String[]{AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM},
+                    new String[]{AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM,
+                            AccountConstants.ACCOUNT_STATE_CLAIM_URI},
                     UserCoreConstants.DEFAULT_PROFILE);
             existingAccountLockedValue = Boolean.parseBoolean(claimValues.get(AccountConstants.ACCOUNT_LOCKED_CLAIM));
-
+            IdentityUtil.threadLocalProperties.get().put(AccountConstants.PREVIOUS_ACCOUNT_STATE,
+                    claimValues.get(AccountConstants.ACCOUNT_STATE_CLAIM_URI));
         } catch (UserStoreException e) {
             throw new AccountLockException(String.format("Error occurred while retrieving %s and %s claim values",
                     AccountConstants.ACCOUNT_LOCKED_CLAIM, AccountConstants.ACCOUNT_UNLOCK_TIME_CLAIM), e);
@@ -662,6 +664,14 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
 
             String existingAccountStateClaimValue = getAccountState(claimValues.get(AccountConstants
                     .ACCOUNT_STATE_CLAIM_URI), tenantDomain);
+            String previousAccountStateClaimValue = "";
+            if (IdentityUtil.threadLocalProperties.get().get(AccountConstants.PREVIOUS_ACCOUNT_STATE) != null) {
+                previousAccountStateClaimValue =
+                        getAccountState(
+                                (String) IdentityUtil.threadLocalProperties.get()
+                                        .get(AccountConstants.PREVIOUS_ACCOUNT_STATE),
+                                tenantDomain);
+            }
             try {
                 notificationInternallyManage = Boolean.parseBoolean(AccountUtil.getConnectorConfig(AccountConstants
                         .NOTIFICATION_INTERNALLY_MANAGE, tenantDomain));
@@ -698,13 +708,13 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                         }
                     }
                     boolean isPendingSelfRegistration =
-                            AccountConstants.PENDING_SELF_REGISTRATION.equals(existingAccountStateClaimValue);
+                            AccountConstants.PENDING_SELF_REGISTRATION.equals(previousAccountStateClaimValue);
                     boolean isPendingLiteRegistration =
-                            AccountConstants.PENDING_LITE_REGISTRATION.equals(existingAccountStateClaimValue);
+                            AccountConstants.PENDING_LITE_REGISTRATION.equals(previousAccountStateClaimValue);
                     boolean isPendingAskPassword =
-                            AccountConstants.PENDING_ASK_PASSWORD.equals(existingAccountStateClaimValue);
+                            AccountConstants.PENDING_ASK_PASSWORD.equals(previousAccountStateClaimValue);
                     if (IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
-                            .equals(existingAccountStateClaimValue)) {
+                            .equals(previousAccountStateClaimValue)) {
                         if (adminForcedPasswordResetUnlockNotificationEnabled) {
                             triggerNotification(userName, userStoreDomainName, tenantDomain, identityProperties,
                                     emailTemplateTypeAccUnlocked);
@@ -799,6 +809,7 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
         } finally {
             lockedState.remove();
             IdentityUtil.threadLocalProperties.get().remove(AccountConstants.ADMIN_INITIATED);
+            IdentityUtil.threadLocalProperties.get().remove(AccountConstants.PREVIOUS_ACCOUNT_STATE);
         }
         if (StringUtils.isNotEmpty(newAccountState)) {
             userClaims.put(AccountConstants.ACCOUNT_STATE_CLAIM_URI, newAccountState);

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -73,6 +73,7 @@ public class AccountConstants {
 
     public static final String ADMIN_INITIATED = "AdminInitiated";
     public static final String MAX_ATTEMPTS_EXCEEDED = "MaxAttemptsExceeded";
+    public static final String PREVIOUS_ACCOUNT_STATE = "PreviousAccountState";
 
     public static final String ACCOUNT_UNLOCK_TIME = "AccountUnlockTime";
 


### PR DESCRIPTION
### Proposed changes in this pull request

- With this PR the following changes have been made to ensure the correct sending of the account unlock email.
    - At `handlePreSetUserClaimValues()`, previous state of the account is added to thread local properties.
    - This previous account state is read and checked before sending account unlock email at `handlePostSetUserClaimValues()` instead of the current account state claim. 
