### PR TITLE
Disable account unlock notification for user creation with Email Verification Enabled

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/AccountLockHandler.java
@@ -751,6 +751,11 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                             AccountConstants.PENDING_LITE_REGISTRATION.equals(previousAccountStateClaimValue);
                     boolean isPendingAskPassword =
                             AccountConstants.PENDING_ASK_PASSWORD.equals(previousAccountStateClaimValue);
+                    boolean isPendingEmailVerification =
+                            AccountConstants.PENDING_EMAIL_VERIFICATION.equals(existingAccountStateClaimValue);
+                    boolean disableUnlockStateInEmailVerification =
+                            Boolean.parseBoolean(
+                                    IdentityUtil.getProperty(AccountConstants.DISABLE_ACCOUNT_UNLOCK_NOTIFICATION));
                     if (IdentityMgtConstants.AccountStates.PENDING_ADMIN_FORCED_USER_PASSWORD_RESET
                             .equals(previousAccountStateClaimValue)) {
                         if (adminForcedPasswordResetUnlockNotificationEnabled) {
@@ -758,7 +763,8 @@ public class AccountLockHandler extends AbstractEventHandler implements Identity
                                     emailTemplateTypeAccUnlocked);
                         }
                     } else if (!isPendingSelfRegistration && !isPendingLiteRegistration &&
-                            !(isPendingAskPassword && isAccountLockOnCreationEnabled(tenantDomain))) {
+                            !(isPendingAskPassword && isAccountLockOnCreationEnabled(tenantDomain)) &&
+                            !(isPendingEmailVerification && disableUnlockStateInEmailVerification)) {
                         triggerNotification(userName, userStoreDomainName, tenantDomain, identityProperties,
                                 emailTemplateTypeAccUnlocked);
                     }

--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -88,5 +88,6 @@ public class AccountConstants {
     public static final String LOCK_DURATION_EMAIL_TEMPLATE_PARAMETER = "lock-duration";
 
     public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";
+    public static final String DISABLE_ACCOUNT_UNLOCK_NOTIFICATION = "EmailVerification.DisableNotifyUnlockState";
 }
 


### PR DESCRIPTION
Fixes https://github.com/wso2/product-is/issues/21207

Need to enable the config:
```
[identity_mgt.user_onboarding]
disable_notify_unlock_state=true
```