### PR TITLE
Add failed login attempts to audit log

### DIFF
--- a/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
+++ b/components/org.wso2.carbon.identity.handler.event.account.lock/src/main/java/org/wso2/carbon/identity/handler/event/account/lock/constants/AccountConstants.java
@@ -89,5 +89,7 @@ public class AccountConstants {
 
     public static final String EMAIL_ACCOUNT_LOCK_ON_CREATION = "EmailVerification.LockOnCreation";
     public static final String DISABLE_ACCOUNT_UNLOCK_NOTIFICATION = "EmailVerification.DisableNotifyUnlockState";
+
+    public static final String RESOLVED_FAILED_LOGIN_ATTEMPT_CLAIM = "ResolvedFailedLoginAttemptClaim";
 }
 


### PR DESCRIPTION
### Proposed changes in this pull request
Add failed login attempts to audit log

Eg: 
```
TID: [2] Tenant: [testasgardeo2] [2025-06-11 21:31:25,189] [f1b6659e-f060-4de3-b6a2-90264a1cea01] : iam-cloud-audit :  INFO {AUDIT_LOG} - Initiator : w**************r | Action : Account Lock | Target : t*************m | Data : {"ServiceProviderName":"spanew1","AdminInitiated":true,"modifiedStatus":false,"User Identity Claims":{"http://wso2.org/claims/identity/lockedReason":"MAX_ATTEMPTS_EXCEEDED","http://wso2.org/claims/identity/idpType":"Local","http://wso2.org/claims/identity/accountState":"LOCKED","http://wso2.org/claims/identity/unlockTime":"1749655751562","http://wso2.org/claims/identity/userSource":"DEFAULT","http://wso2.org/claims/identity/failedSmsOtpAttempts":"2"},"UserStoreDomain":"DEFAULT"} | Result : Success


TID: [2] Tenant: [testasgardeo2] [2025-06-11 21:32:56,205] [ed920c22-c455-4af7-8cdc-341144b21604] : iam-cloud-audit :  INFO {AUDIT_LOG} - Initiator : w**************r | Action : Account Lock | Target : t*************m | Data : {"ServiceProviderName":"spanew1","AdminInitiated":true,"modifiedStatus":false,"User Identity Claims":{"http://wso2.org/claims/identity/failedLoginAttempts":"2","http://wso2.org/claims/identity/lockedReason":"MAX_ATTEMPTS_EXCEEDED","http://wso2.org/claims/identity/idpType":"Local","http://wso2.org/claims/identity/accountState":"LOCKED","http://wso2.org/claims/identity/unlockTime":"1749655751562","http://wso2.org/claims/identity/userSource":"DEFAULT"},"UserStoreDomain":"DEFAULT"} | Result : Success
```
